### PR TITLE
Fix PDF text extraction when pages have no text

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,9 @@ def get_pdf_text(pdf_docs):
     for pdf in pdf_docs:
         pdf_reader = PdfReader(pdf)
         for page in pdf_reader.pages:
-            text += page.extract_text()  # Extrai o texto de cada página
+            page_text = page.extract_text()
+            if page_text:
+                text += page_text  # Extrai o texto de cada página, ignorando páginas sem texto
     return text
 
 def get_text_chunks(text):


### PR DESCRIPTION
## Summary
- handle `None` return from `PyPDF2` when extracting text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c10c19a48325adc6d085de449b0d