### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -53,3 +53,5 @@ Para usar o MultiPDF Chat App, siga estes passos:
 4. Carregue vários documentos PDF no aplicativo, seguindo as instruções fornecidas.
 
 5. Faça perguntas em linguagem natural sobre os PDFs carregados usando a interface de chat.
+## Licença
+Este projeto está licenciado sob os termos do MIT License - veja o arquivo [LICENSE](LICENSE) para detalhes.


### PR DESCRIPTION
## Summary
- add MIT License file
- reference the license in the readme

## Testing
- `python -m py_compile app.py htmlTemplates.py` *(fails: pyenv couldn't find python 3.9)*

------
https://chatgpt.com/codex/tasks/task_e_6840c25bed9c8325b8963ad2f8949ca0