### PR TITLE
Add basic tests and pytest install docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,11 @@ Para instalar o MultiPDF Chat App, siga estes passos:
    pip install -r requirements.txt
    ```
 
-3. Obtenha uma chave de API da OpenAI e adicione-a ao arquivo `.env` no diretório do projeto.
+3. Instale o **pytest** para executar os testes da aplicação. Recomenda-se utilizar um ambiente virtual:
+   ```
+   pip install pytest
+   ```
+4. Obtenha uma chave de API da OpenAI e adicione-a ao arquivo `.env` no diretório do projeto.
 ```commandline
 OPENAI_API_KEY=your_secrit_api_key
 ```

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,41 @@
+import builtins
+import app
+from unittest.mock import patch
+
+
+def test_get_pdf_text(monkeypatch):
+    class DummyPage:
+        def __init__(self, text):
+            self.text = text
+        def extract_text(self):
+            return self.text
+
+    class DummyReader:
+        def __init__(self, file):
+            pass
+        @property
+        def pages(self):
+            return [DummyPage('text1'), DummyPage(None)]
+
+    monkeypatch.setattr(app, 'PdfReader', lambda _: DummyReader(_))
+    result = app.get_pdf_text([object(), object()])
+    assert result == 'text1text1'
+
+
+def test_get_text_chunks(monkeypatch):
+    calls = {}
+    class DummySplitter:
+        def __init__(self, separator, chunk_size, chunk_overlap, length_function):
+            calls['params'] = (separator, chunk_size, chunk_overlap, length_function)
+        def split_text(self, text):
+            calls['text'] = text
+            return ['chunkA', 'chunkB']
+
+    monkeypatch.setattr(app, 'CharacterTextSplitter', DummySplitter)
+    chunks = app.get_text_chunks('sample text')
+    assert chunks == ['chunkA', 'chunkB']
+    assert calls['text'] == 'sample text'
+    assert calls['params'][0] == '\n'
+    assert calls['params'][1] == 1000
+    assert calls['params'][2] == 100
+    assert calls['params'][3]('ab') == 2


### PR DESCRIPTION
## Summary
- add unit tests for `get_pdf_text` and `get_text_chunks`
- document pytest installation in `readme.md`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2670f548325a2502de9b8ec5497